### PR TITLE
Implement login API service and replace mock authentication

### DIFF
--- a/mobile-app/app/(tabs)/index.tsx
+++ b/mobile-app/app/(tabs)/index.tsx
@@ -5,14 +5,15 @@ import {
   TextInput,
   TouchableOpacity,
   StyleSheet,
-  Image,
   Alert,
   KeyboardAvoidingView,
   Platform,
+  AsyncStorage,
 } from 'react-native';
 import { LinearGradient } from 'expo-linear-gradient';
 import { useRouter } from 'expo-router';
 import AISupport from '@/components/AISupport';
+import { loginService } from '@/services/loginService';
 
 export default function LoginScreen() {
   const [email, setEmail] = useState('');
@@ -20,18 +21,26 @@ export default function LoginScreen() {
   const [userType, setUserType] = useState<'admin' | 'student'>('student');
   const router = useRouter();
 
-  const handleLogin = () => {
+  const handleLogin = async () => {
     if (!email || !password) {
       Alert.alert('Erro', 'Por favor, preencha todos os campos');
       return;
     }
 
-    // Mock authentication
-    if (userType === 'admin' && email === 'admin@justdive.com' && password === 'admin') {
-      router.push('/admin-dashboard');
-    } else if (userType === 'student' && email === 'student@justdive.com' && password === 'student') {
-      router.push('/student-dashboard');
-    } else {
+    try {
+      const { token, profile } = await loginService(email, password, userType);
+      if (Platform.OS === 'web') {
+        localStorage.setItem('sessionToken', token);
+      } else {
+        await AsyncStorage.setItem('sessionToken', token);
+      }
+
+      if (profile === 'admin') {
+        router.push('/admin-dashboard');
+      } else {
+        router.push('/student-dashboard');
+      }
+    } catch {
       Alert.alert('Erro', 'Credenciais inválidas');
     }
   };

--- a/mobile-app/services/loginService.ts
+++ b/mobile-app/services/loginService.ts
@@ -1,0 +1,26 @@
+const API_BASE_URL = process.env.EXPO_PUBLIC_API_URL || 'http://localhost:5000';
+
+type LoginResponse = {
+  token: string;
+  profile: 'admin' | 'student';
+};
+
+export async function loginService(
+  email: string,
+  password: string,
+  userType: 'admin' | 'student'
+): Promise<LoginResponse> {
+  const response = await fetch(`${API_BASE_URL}/api/users/login`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ email, password, userType }),
+  });
+
+  if (!response.ok) {
+    throw new Error('Login failed');
+  }
+
+  return response.json();
+}


### PR DESCRIPTION
## Summary
- add login service that calls Flask backend for session token
- replace mock login logic with async API call and token storage

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c444b06e8c832da1a9b6b260afaa8c