### PR TITLE
feat: add AI chat endpoint and integrate frontends

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -14,6 +14,7 @@ from src.models.user import db
 from src.routes.user import user_bp
 from src.routes.weather import weather_bp
 from src.routes.students import students_bp
+from src.routes.ai import ai_bp
 
 app = Flask(__name__, static_folder=os.path.join(os.path.dirname(__file__), 'static'))
 
@@ -27,6 +28,7 @@ CORS(app, origins="*")
 app.register_blueprint(user_bp, url_prefix='/api')
 app.register_blueprint(weather_bp)
 app.register_blueprint(students_bp)
+app.register_blueprint(ai_bp)
 
 # Configuração da base de dados
 app.config['SQLALCHEMY_DATABASE_URI'] = f"sqlite:///{os.path.join(os.path.dirname(__file__), 'database', 'app.db')}"

--- a/src/routes/ai.py
+++ b/src/routes/ai.py
@@ -1,0 +1,19 @@
+"""Rotas da API para interações com IA"""
+from flask import Blueprint, request, jsonify
+from src.services.openai_service import openai_service
+
+ai_bp = Blueprint('ai', __name__, url_prefix='/api/ai')
+
+@ai_bp.route('/chat', methods=['POST'])
+def chat():
+    """Endpoint de chat simples com o serviço OpenAI"""
+    try:
+        data = request.get_json()
+        if not data or 'message' not in data:
+            return jsonify({'error': 'Mensagem é obrigatória'}), 400
+
+        message = data['message']
+        response_text = openai_service.chat(message)
+        return jsonify({'success': True, 'response': response_text})
+    except Exception as e:
+        return jsonify({'error': 'Erro ao processar mensagem', 'details': str(e)}), 500

--- a/src/services/openai_service.py
+++ b/src/services/openai_service.py
@@ -15,8 +15,25 @@ class OpenAIService:
         # Configurar cliente OpenAI
         openai.api_key = self.api_key
         openai.api_base = self.api_url
-        
+
         self.model = "gpt-3.5-turbo"
+
+    def chat(self, message: str) -> str:
+        """Realiza uma interação simples de chat com o modelo da OpenAI."""
+        try:
+            response = openai.ChatCompletion.create(
+                model=self.model,
+                messages=[
+                    {"role": "system", "content": "És um assistente da JUSTDIVE Academy."},
+                    {"role": "user", "content": message}
+                ],
+                max_tokens=300,
+                temperature=0.7
+            )
+            return response.choices[0].message.content.strip()
+        except Exception as e:
+            print(f"Erro no chat OpenAI: {e}")
+            return "Desculpe, não foi possível obter resposta da IA no momento."
         
     def analyze_weather_conditions(self, weather_data: Dict) -> Dict:
         """


### PR DESCRIPTION
## Summary
- add OpenAI chat support service and API endpoint
- wire mobile AISupport and PWA AIChat components to backend chat endpoint
- show typing feedback and handle network errors on both clients

## Testing
- `pytest`
- `npm test` (mobile-app) *(fails: Missing script "test")*
- `npm test` (pwa-corrected) *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c44614efe8832da0e065c315d94611