### PR TITLE
Normalize weather metrics for AI weather analysis

### DIFF
--- a/src/routes/weather.py
+++ b/src/routes/weather.py
@@ -6,6 +6,7 @@ from src.services.weather_service import weather_service
 from src.services.supabase_service import supabase_service
 from src.services.openai_service import openai_service
 from src.services.notification_service import notification_service
+from src.utils.weather import normalize_conditions
 from datetime import datetime
 
 weather_bp = Blueprint('weather', __name__, url_prefix='/api/weather')
@@ -196,16 +197,18 @@ def get_weather_widget_data(location):
             return jsonify({'error': 'Local não encontrado'}), 404
         
         # Dados simplificados para widget
+        conditions = normalize_conditions(weather_data)
+
         widget_data = {
             'location': weather_data['location'],
             'status': weather_data['status'],
             'status_text': {
                 'GREEN': 'Condições Excelentes',
-                'YELLOW': 'Atenção Necessária', 
+                'YELLOW': 'Atenção Necessária',
                 'RED': 'Mergulho Cancelado'
             }.get(weather_data['status'], 'Status Desconhecido'),
-            'wave_height': weather_data['conditions']['wave_height'],
-            'wind_speed': weather_data['conditions']['wind_speed'],
+            'wave_height': conditions.get('wave_height'),
+            'wind_speed': conditions.get('wind_speed'),
             'next_update': weather_data['next_update'],
             'timestamp': weather_data['timestamp']
         }

--- a/src/utils/weather.py
+++ b/src/utils/weather.py
@@ -1,0 +1,68 @@
+"""Utility helpers for working with weather payloads."""
+from __future__ import annotations
+
+from typing import Any, Dict
+
+# Mapping of the flat payload keys provided by WeatherService to normalized snake_case keys
+_METRIC_MAP = {
+    "waveHeight": ("wave_height", 0.0),
+    "windSpeed": ("wind_speed", 0.0),
+    "gust": ("gust", 0.0),
+    "precipitation": ("precipitation", 0.0),
+    "visibility": ("visibility", 10.0),
+    "waterTemperature": ("water_temperature", 18.0),
+    "wavePeriod": ("wave_period", 0.0),
+    "airTemperature": ("air_temperature", 20.0),
+}
+
+
+def _to_float(value: Any, default: float) -> float:
+    """Convert a value to float safely, returning the provided default on failure."""
+    if value is None:
+        return default
+
+    if isinstance(value, (int, float)):
+        return round(float(value), 1)
+
+    try:
+        cleaned = str(value).strip()
+        if not cleaned:
+            return default
+        cleaned = cleaned.replace(",", ".")
+        return round(float(cleaned), 1)
+    except (TypeError, ValueError):
+        return default
+
+
+def normalize_conditions(weather_data: Dict[str, Any]) -> Dict[str, float]:
+    """Return a normalized dictionary of weather metrics.
+
+    The Stormglass payload processed by ``WeatherService`` exposes flattened keys such as
+    ``waveHeight`` or ``windSpeed``. Some historical records might still contain the legacy
+    ``conditions`` dictionary with snake_case keys. This helper consolidates both formats
+    into a single dictionary, ensuring downstream consumers can rely on consistent keys.
+    """
+
+    normalized: Dict[str, float] = {}
+    legacy_conditions = weather_data.get("conditions")
+
+    for flat_key, (normalized_key, default) in _METRIC_MAP.items():
+        value: Any = None
+
+        if isinstance(legacy_conditions, dict):
+            value = legacy_conditions.get(normalized_key)
+            if value is None:
+                value = legacy_conditions.get(flat_key)
+
+        if value is None:
+            value = weather_data.get(flat_key)
+
+        if value is None:
+            value = weather_data.get(normalized_key)
+
+        normalized[normalized_key] = _to_float(value, default)
+
+    return normalized
+
+
+__all__ = ["normalize_conditions"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,6 @@
+import os
+import sys
+
+PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, PROJECT_ROOT)

--- a/tests/test_weather_analysis.py
+++ b/tests/test_weather_analysis.py
@@ -1,0 +1,84 @@
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from src.services.openai_service import OpenAIService
+from src.main import app
+
+
+@pytest.fixture
+def client():
+    with app.test_client() as client:
+        yield client
+
+
+@patch("src.services.openai_service.openai.ChatCompletion.create")
+def test_analyze_weather_conditions_from_flat_payload(mock_chat_create):
+    mock_chat_create.return_value = SimpleNamespace(
+        choices=[SimpleNamespace(message=SimpleNamespace(content="Condições analisadas com sucesso."))]
+    )
+
+    service = OpenAIService()
+    weather_data = {
+        "location": "Peniche",
+        "status": "GREEN",
+        "waveHeight": 1.2,
+        "windSpeed": 14.6,
+        "gust": 18.2,
+        "precipitation": 5.0,
+        "visibility": 9.5,
+        "waterTemperature": 17.8,
+        "airTemperature": 20.1,
+    }
+
+    result = service.analyze_weather_conditions(weather_data)
+
+    assert result["analysis"] == "Condições analisadas com sucesso."
+    assert result["conditions_analyzed"]["wave_height"] == pytest.approx(1.2)
+    assert result["conditions_analyzed"]["wind_speed"] == pytest.approx(14.6)
+    assert result["conditions_analyzed"]["water_temperature"] == pytest.approx(17.8)
+    assert result["conditions_analyzed"]["air_temperature"] == pytest.approx(20.1)
+
+
+def test_weather_analysis_route_returns_textual_response(client):
+    sample_weather = {
+        "location": "Sesimbra",
+        "status": "YELLOW",
+        "waveHeight": 1.4,
+        "windSpeed": 16.0,
+        "gust": 22.0,
+        "precipitation": 10.0,
+        "visibility": 7.0,
+        "waterTemperature": 18.0,
+        "timestamp": "2024-05-15T10:00:00",
+        "next_update": "2024-05-15T10:15:00",
+        "source": "stormglass_api",
+    }
+
+    sample_analysis = {
+        "analysis": "As condições exigem atenção adicional, mas os mergulhos podem ocorrer com precaução.",
+        "timestamp": "2024-05-15T10:01:00",
+        "location": "Sesimbra",
+        "conditions_analyzed": {
+            "wave_height": 1.4,
+            "wind_speed": 16.0,
+            "gust": 22.0,
+            "precipitation": 10.0,
+            "visibility": 7.0,
+            "water_temperature": 18.0,
+            "wave_period": 0.0,
+            "air_temperature": 20.0,
+        },
+    }
+
+    with patch("src.routes.weather.weather_service.get_weather_data", return_value=sample_weather), \
+         patch("src.routes.weather.openai_service.analyze_weather_conditions", return_value=sample_analysis):
+        response = client.get("/api/weather/analysis/sesimbra")
+
+    assert response.status_code == 200
+    payload = response.get_json()
+    assert payload["success"] is True
+    assert isinstance(payload["ai_analysis"]["analysis"], str)
+    assert payload["ai_analysis"]["analysis"].strip() != ""
+    assert payload["weather_data"]["waveHeight"] == pytest.approx(1.4)


### PR DESCRIPTION
## Summary
- add a utility helper to normalize weather metrics from the flattened Stormglass payload
- update the OpenAI weather analysis flow and Supabase persistence to consume the normalized metrics while keeping backwards compatibility
- adjust the weather widget route and add regression tests for the AI analysis endpoint

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cc2d329810832da4bea51993464bde