### PR TITLE
Add demo login endpoint and update mobile login flow

### DIFF
--- a/mobile-app/app/(tabs)/index.tsx
+++ b/mobile-app/app/(tabs)/index.tsx
@@ -8,8 +8,8 @@ import {
   Alert,
   KeyboardAvoidingView,
   Platform,
-  AsyncStorage,
 } from 'react-native';
+import AsyncStorage from '@react-native-async-storage/async-storage';
 import { LinearGradient } from 'expo-linear-gradient';
 import { useRouter } from 'expo-router';
 import AISupport from '@/components/AISupport';

--- a/mobile-app/package.json
+++ b/mobile-app/package.json
@@ -16,6 +16,7 @@
     "@react-navigation/bottom-tabs": "^7.4.0",
     "@react-navigation/elements": "^2.6.3",
     "@react-navigation/native": "^7.1.8",
+    "@react-native-async-storage/async-storage": "^1.24.0",
     "expo": "~54.0.2",
     "expo-constants": "~18.0.8",
     "expo-font": "~14.0.8",

--- a/mobile-app/services/loginService.ts
+++ b/mobile-app/services/loginService.ts
@@ -1,4 +1,5 @@
-const API_BASE_URL = process.env.EXPO_PUBLIC_API_URL || 'http://localhost:5000';
+const API_BASE_URL = (process.env.EXPO_PUBLIC_API_URL || 'http://localhost:5000').replace(/\/$/, '');
+const LOGIN_ENDPOINT = '/api/users/login';
 
 type LoginResponse = {
   token: string;
@@ -10,7 +11,7 @@ export async function loginService(
   password: string,
   userType: 'admin' | 'student'
 ): Promise<LoginResponse> {
-  const response = await fetch(`${API_BASE_URL}/api/users/login`, {
+  const response = await fetch(`${API_BASE_URL}${LOGIN_ENDPOINT}`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
@@ -18,9 +19,12 @@ export async function loginService(
     body: JSON.stringify({ email, password, userType }),
   });
 
-  if (!response.ok) {
-    throw new Error('Login failed');
+  const responseBody = await response.json().catch(() => null);
+
+  if (!response.ok || !responseBody) {
+    const message = responseBody?.message ?? 'Login failed';
+    throw new Error(message);
   }
 
-  return response.json();
+  return responseBody;
 }

--- a/src/routes/user.py
+++ b/src/routes/user.py
@@ -3,6 +3,44 @@ from src.models.user import User, db
 
 user_bp = Blueprint('user', __name__)
 
+DEMO_USERS = {
+    'student@justdive.com': {
+        'password': 'student',
+        'profile': 'student'
+    },
+    'admin@justdive.com': {
+        'password': 'admin',
+        'profile': 'admin'
+    }
+}
+
+
+@user_bp.route('/users/login', methods=['POST'])
+def login_user():
+    data = request.get_json(silent=True) or {}
+
+    email = data.get('email', '').strip().lower()
+    password = data.get('password')
+    requested_profile = data.get('userType')
+
+    if not email or not password:
+        return jsonify({'message': 'Missing credentials'}), 400
+
+    demo_user = DEMO_USERS.get(email)
+
+    if not demo_user or demo_user['password'] != password:
+        return jsonify({'message': 'Invalid credentials'}), 401
+
+    profile = demo_user['profile']
+
+    if requested_profile and requested_profile != profile:
+        return jsonify({'message': 'Invalid credentials'}), 401
+
+    token = f"{profile}-demo-token"
+
+    return jsonify({'token': token, 'profile': profile}), 200
+
+
 @user_bp.route('/users', methods=['GET'])
 def get_users():
     users = User.query.all()


### PR DESCRIPTION
## Summary
- add a demo login endpoint that validates the admin and student credentials expected by the mobile app and returns profile tokens
- update the Expo login service to target the new endpoint, reuse the base API URL, and surface server error messages
- switch the login screen to use AsyncStorage from @react-native-async-storage/async-storage and declare the dependency for the mobile app bundle

## Testing
- PYTHONPATH=. pytest

------
https://chatgpt.com/codex/tasks/task_e_68cc2d33bee8832d8386114cdd2e2337