### PR TITLE
Improve push notification registration logging

### DIFF
--- a/mobile-app/hooks/use-push-notifications.ts
+++ b/mobile-app/hooks/use-push-notifications.ts
@@ -1,30 +1,69 @@
 import { useEffect, useState } from 'react';
 import * as Notifications from 'expo-notifications';
 
+import { getApiBase } from '@/utils/config';
+
 export function usePushNotifications() {
   const [token, setToken] = useState<string | null>(null);
 
   useEffect(() => {
     async function register() {
-      const { status: existingStatus } = await Notifications.getPermissionsAsync();
-      let finalStatus = existingStatus;
-      if (existingStatus !== 'granted') {
-        const { status } = await Notifications.requestPermissionsAsync();
-        finalStatus = status;
-      }
-      if (finalStatus !== 'granted') {
-        return;
-      }
-      const pushToken = (await Notifications.getExpoPushTokenAsync()).data;
-      setToken(pushToken);
       try {
-        await fetch('/api/notifications/register', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ token: pushToken })
-        });
-      } catch (e) {
-        console.log('Erro ao registar token de notificação', e);
+        const { status: existingStatus } = await Notifications.getPermissionsAsync();
+        let finalStatus = existingStatus;
+        if (existingStatus !== 'granted') {
+          const { status } = await Notifications.requestPermissionsAsync();
+          finalStatus = status;
+        }
+        if (finalStatus !== 'granted') {
+          console.warn('[PushNotifications] Notification permissions not granted.');
+          return;
+        }
+        const pushToken = (await Notifications.getExpoPushTokenAsync()).data;
+        console.log(`[PushNotifications] Obtained Expo push token: ${pushToken}`);
+        setToken(pushToken);
+
+        const apiBase = getApiBase();
+        const registerUrl = `${apiBase}/api/notifications/register`;
+        const maxAttempts = 3;
+
+        for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+          try {
+            console.log(
+              `[PushNotifications] Registering push token (attempt ${attempt}/${maxAttempts}) at ${registerUrl}`
+            );
+
+            const response = await fetch(registerUrl, {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({ token: pushToken })
+            });
+
+            if (!response.ok) {
+              const message = await response.text().catch(() => '');
+              const details = message ? ` - ${message}` : '';
+              throw new Error(
+                `Unexpected response when registering push token: ${response.status} ${response.statusText}${details}`
+              );
+            }
+
+            console.log('[PushNotifications] Push token registered successfully.');
+            break;
+          } catch (e) {
+            console.error('[PushNotifications] Failed to register push token', e);
+
+            if (attempt === maxAttempts) {
+              console.error('[PushNotifications] Giving up after maximum retries.');
+              break;
+            }
+
+            const delay = attempt * 1000;
+            console.log(`[PushNotifications] Retrying in ${delay}ms...`);
+            await new Promise((resolve) => setTimeout(resolve, delay));
+          }
+        }
+      } catch (error) {
+        console.error('[PushNotifications] Unexpected error while registering for notifications', error);
       }
     }
 

--- a/mobile-app/utils/config.ts
+++ b/mobile-app/utils/config.ts
@@ -1,0 +1,22 @@
+const FALLBACK_API_BASE = 'http://localhost:5000';
+
+/**
+ * Returns the API base URL configured for the mobile application.
+ *
+ * The value is read from the Expo public environment variable
+ * `EXPO_PUBLIC_API_URL`. When the variable is not defined, a sensible
+ * default pointing to the local development server is returned.
+ */
+export function getApiBase(): string {
+  const envValue = process.env.EXPO_PUBLIC_API_URL?.trim();
+
+  if (!envValue) {
+    console.warn(
+      '[Config] EXPO_PUBLIC_API_URL is not defined. Falling back to http://localhost:5000'
+    );
+    return FALLBACK_API_BASE;
+  }
+
+  const normalized = envValue.replace(/\/+$/, '');
+  return normalized.length > 0 ? normalized : FALLBACK_API_BASE;
+}

--- a/src/services/notification_service.py
+++ b/src/services/notification_service.py
@@ -16,8 +16,14 @@ class NotificationService:
 
     def register_token(self, token: str) -> None:
         """Store the Expo push token if it hasn't been registered yet."""
-        if token and token not in self.tokens:
+        if not token:
+            return
+
+        if token not in self.tokens:
             self.tokens.append(token)
+            print(f"[NotificationService] Registered new Expo push token: {token}")
+        else:
+            print(f"[NotificationService] Expo push token already registered: {token}")
 
     def send_notification(self, title: str, message: str) -> None:
         """


### PR DESCRIPTION
## Summary
- add a configuration helper that resolves the Expo public API base URL for the mobile app
- update the push notification hook to use the helper, add detailed logging, and retry push token registration
- log notification tokens on the backend notification service when they are registered

## Testing
- PYTHONPATH=. pytest

------
https://chatgpt.com/codex/tasks/task_e_68cc2d391f2c832d8f47126d2a4ce802