### PR TITLE
feat: improve weather data handling in mobile app

### DIFF
--- a/mobile-app/app/(tabs)/student-dashboard.tsx
+++ b/mobile-app/app/(tabs)/student-dashboard.tsx
@@ -11,20 +11,31 @@ import {
 import { LinearGradient } from 'expo-linear-gradient';
 import { router } from 'expo-router';
 import { fetchCurrentWeather, WeatherData } from '../../services/weatherService';
+import { WEATHER_ERROR_MESSAGE } from '../../services/weatherApi';
 
 const { width } = Dimensions.get('window');
 
 export default function StudentDashboardScreen() {
   const [weatherData, setWeatherData] = useState<WeatherData | null>(null);
   const [loadingWeather, setLoadingWeather] = useState(true);
+  const [weatherError, setWeatherError] = useState<string | null>(null);
   const nextClass = '14:30 - Mergulho Avançado';
 
   const loadWeather = async () => {
+    setWeatherError(null);
+    setLoadingWeather(true);
+
     try {
       const data = await fetchCurrentWeather('lagos');
       setWeatherData(data);
     } catch (err) {
-      console.error(err);
+      console.error('Erro ao carregar condições meteorológicas:', err);
+      const message =
+        err instanceof Error && err.message
+          ? err.message
+          : WEATHER_ERROR_MESSAGE;
+      setWeatherError(message);
+      setWeatherData(null);
     } finally {
       setLoadingWeather(false);
     }
@@ -88,9 +99,11 @@ export default function StudentDashboardScreen() {
         {/* Weather Status Card */}
         <View style={styles.card}>
           <Text style={styles.cardTitle}>Estado Meteorológico</Text>
-          {loadingWeather || !weatherData ? (
-            <Text style={{ color: 'white' }}>Carregando...</Text>
-          ) : (
+          {loadingWeather && !weatherData ? (
+            <Text style={styles.messageText}>Carregando...</Text>
+          ) : weatherError ? (
+            <Text style={styles.errorText}>{weatherError}</Text>
+          ) : weatherData ? (
             <View style={styles.weatherContainer}>
               <View
                 style={[
@@ -107,6 +120,8 @@ export default function StudentDashboardScreen() {
                 </Text>
               </View>
             </View>
+          ) : (
+            <Text style={styles.messageText}>Sem dados meteorológicos disponíveis.</Text>
           )}
         </View>
 
@@ -256,6 +271,8 @@ const styles = StyleSheet.create({
   weatherInfo: { flex: 1 },
   weatherStatus: { fontSize: 16, fontWeight: '600', color: 'white', marginBottom: 4 },
   weatherDetails: { fontSize: 14, color: '#A0AEC0' },
+  messageText: { color: 'white', textAlign: 'center' },
+  errorText: { color: '#F87171', textAlign: 'center', fontWeight: '600' },
   classContainer: { alignItems: 'flex-start' },
   classTime: { fontSize: 18, fontWeight: 'bold', color: '#00FFFF', marginBottom: 8 },
   classLocation: { fontSize: 14, color: '#A0AEC0', marginBottom: 16 },

--- a/mobile-app/constants/api.ts
+++ b/mobile-app/constants/api.ts
@@ -1,0 +1,27 @@
+const DEFAULT_API_BASE_URL = 'http://localhost:3000';
+
+function sanitizeBaseUrl(url: string): string {
+  const trimmed = url.trim();
+  if (!trimmed) {
+    return DEFAULT_API_BASE_URL;
+  }
+  return trimmed.replace(/\/+$/, '') || DEFAULT_API_BASE_URL;
+}
+
+const rawBaseUrl = process.env.EXPO_PUBLIC_API_URL ?? DEFAULT_API_BASE_URL;
+
+export const API_BASE_URL = sanitizeBaseUrl(rawBaseUrl);
+
+export function buildApiUrl(path: string): string {
+  if (!path) {
+    return API_BASE_URL;
+  }
+
+  if (/^https?:\/\//i.test(path)) {
+    return path;
+  }
+
+  const normalizedPath = path.startsWith('/') ? path : `/${path}`;
+  return `${API_BASE_URL}${normalizedPath}`;
+}
+

--- a/mobile-app/services/weatherApi.ts
+++ b/mobile-app/services/weatherApi.ts
@@ -1,9 +1,30 @@
-const API_URL = process.env.EXPO_PUBLIC_API_URL || 'http://localhost:3000'
+import { buildApiUrl } from '../constants/api';
+
+export const WEATHER_ERROR_MESSAGE =
+  'Não foi possível carregar os dados meteorológicos. Verifique a sua ligação e tente novamente.';
 
 export async function getCurrentWeather(location: string) {
-  const response = await fetch(`${API_URL}/api/weather/current/${location}`)
-  if (!response.ok) {
-    throw new Error('Erro ao buscar dados meteorológicos')
+  const endpoint = `/api/weather/current/${encodeURIComponent(location)}`;
+  const url = buildApiUrl(endpoint);
+
+  try {
+    const response = await fetch(url);
+
+    if (!response.ok) {
+      console.error(
+        `Resposta inválida ao obter dados meteorológicos (${response.status}) para ${location}.`,
+      );
+      throw new Error(WEATHER_ERROR_MESSAGE);
+    }
+
+    return await response.json();
+  } catch (error) {
+    console.error('Erro ao comunicar com o serviço meteorológico:', error);
+
+    if (error instanceof Error && error.message === WEATHER_ERROR_MESSAGE) {
+      throw error;
+    }
+
+    throw new Error(WEATHER_ERROR_MESSAGE);
   }
-  return response.json()
 }

--- a/mobile-app/services/weatherService.ts
+++ b/mobile-app/services/weatherService.ts
@@ -1,3 +1,5 @@
+import { getCurrentWeather, WEATHER_ERROR_MESSAGE } from './weatherApi';
+
 export interface WeatherData {
   temperature: number;
   waveHeight: number;
@@ -7,10 +9,68 @@ export interface WeatherData {
   [key: string]: any;
 }
 
-export async function fetchCurrentWeather(local: string): Promise<WeatherData> {
-  const response = await fetch(`/api/weather/current/${encodeURIComponent(local)}`);
-  if (!response.ok) {
-    throw new Error('Falha ao obter dados meteorológicos');
+const VALID_STATUSES: ReadonlyArray<WeatherData['status']> = ['GREEN', 'YELLOW', 'RED'];
+
+function parseNumericField(value: unknown): number {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value;
   }
-  return response.json();
+
+  if (typeof value === 'string') {
+    const parsed = Number(value);
+    if (Number.isFinite(parsed)) {
+      return parsed;
+    }
+  }
+
+  throw new Error(WEATHER_ERROR_MESSAGE);
+}
+
+function parseStatus(value: unknown): WeatherData['status'] {
+  if (typeof value === 'string') {
+    const normalized = value.toUpperCase() as WeatherData['status'];
+    if (VALID_STATUSES.includes(normalized)) {
+      return normalized;
+    }
+  }
+
+  throw new Error(WEATHER_ERROR_MESSAGE);
+}
+
+function validateWeatherPayload(payload: unknown): WeatherData {
+  if (!payload || typeof payload !== 'object') {
+    throw new Error(WEATHER_ERROR_MESSAGE);
+  }
+
+  const data = payload as Record<string, unknown>;
+
+  const temperature = parseNumericField(data.temperature);
+  const waveHeight = parseNumericField(data.waveHeight);
+  const windSpeed = parseNumericField(data.windSpeed);
+  const visibility = parseNumericField(data.visibility);
+  const status = parseStatus(data.status);
+
+  return {
+    ...data,
+    temperature,
+    waveHeight,
+    windSpeed,
+    visibility,
+    status,
+  } as WeatherData;
+}
+
+export async function fetchCurrentWeather(local: string): Promise<WeatherData> {
+  try {
+    const weather = await getCurrentWeather(local);
+    return validateWeatherPayload(weather);
+  } catch (error) {
+    console.error('Falha ao obter dados meteorológicos:', error);
+
+    if (error instanceof Error) {
+      throw (error.message ? error : new Error(WEATHER_ERROR_MESSAGE));
+    }
+
+    throw new Error(WEATHER_ERROR_MESSAGE);
+  }
 }

--- a/mobile-app/widgets/WeatherWidget.tsx
+++ b/mobile-app/widgets/WeatherWidget.tsx
@@ -3,35 +3,97 @@ import { WidgetTaskHandler, Widget } from 'react-native-android-widget';
 import React from 'react';
 import { View, Text, StyleSheet } from 'react-native';
 
-async function getWeather(location: string) {
-  const response = await fetch(`/api/weather/current/${location}`);
-  return response.json();
+import { fetchCurrentWeather, WeatherData } from '../services/weatherService';
+import { WEATHER_ERROR_MESSAGE } from '../services/weatherApi';
+
+type WidgetWeather = Partial<WeatherData> & { message?: string };
+
+async function getWeather(location: string): Promise<WidgetWeather> {
+  try {
+    return await fetchCurrentWeather(location);
+  } catch (error) {
+    console.error('Erro ao atualizar widget meteorológico:', error);
+    return {
+      message:
+        error instanceof Error && error.message
+          ? error.message
+          : WEATHER_ERROR_MESSAGE,
+    };
+  }
 }
 
-export const WeatherWidget: Widget = ({ weather }) => (
-  <View style={styles.container}>
-    <Text style={styles.status}>{weather.status}</Text>
-    <Text style={styles.temp}>{weather.temperature}\u00B0C</Text>
-  </View>
-);
+const STATUS_LABELS: Record<WeatherData['status'], string> = {
+  GREEN: 'Excelentes condições',
+  YELLOW: 'Condições moderadas',
+  RED: 'Condições perigosas',
+};
+
+function getStatusLabel(weather: WidgetWeather | undefined): string {
+  if (!weather) {
+    return 'Sem dados';
+  }
+
+  if (weather.message) {
+    return weather.message;
+  }
+
+  const status = weather.status as WeatherData['status'] | undefined;
+  if (status && STATUS_LABELS[status]) {
+    return STATUS_LABELS[status];
+  }
+
+  return 'Sem dados';
+}
+
+function getTemperatureLabel(weather: WidgetWeather | undefined): string {
+  if (!weather) {
+    return '--°C';
+  }
+
+  if (typeof weather.temperature === 'number' && Number.isFinite(weather.temperature)) {
+    return `${weather.temperature}°C`;
+  }
+
+  if (typeof weather.temperature === 'string' && weather.temperature.trim() !== '') {
+    return `${weather.temperature}°C`;
+  }
+
+  return '--°C';
+}
+
+export const WeatherWidget: Widget = ({ weather }: { weather?: WidgetWeather }) => {
+  const statusLabel = getStatusLabel(weather);
+  const temperatureLabel = getTemperatureLabel(weather);
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.status}>{statusLabel}</Text>
+      <Text style={styles.temp}>{temperatureLabel}</Text>
+    </View>
+  );
+};
 
 WidgetTaskHandler.setBackgroundHandler(async () => {
-  const weather = await getWeather('default');
+  const weather = await getWeather('lagos');
   return <WeatherWidget weather={weather} />;
 });
 
 const styles = StyleSheet.create({
   container: {
-    backgroundColor: '#fff',
+    backgroundColor: '#ffffff',
     padding: 16,
-    alignItems: 'center'
+    alignItems: 'center',
+    borderRadius: 12,
   },
   status: {
     fontSize: 14,
-    marginBottom: 4
+    marginBottom: 4,
+    textAlign: 'center',
+    color: '#1f2937',
   },
   temp: {
     fontSize: 20,
-    fontWeight: 'bold'
-  }
+    fontWeight: 'bold',
+    color: '#111827',
+  },
 });

--- a/mobile-app/widgets/weather/index.tsx
+++ b/mobile-app/widgets/weather/index.tsx
@@ -1,22 +1,65 @@
-import { widget, Text, View, useWidgetData } from "expo-widget";
+import { widget, Text, View, useWidgetData } from 'expo-widget';
 
-type Weather = {
+import { buildApiUrl } from '../../constants/api';
+import { WEATHER_ERROR_MESSAGE } from '../../services/weatherApi';
+
+type WeatherWidgetData = {
   status: string;
   waves: string;
   wind: string;
+  message?: string;
 };
 
+function sanitizeWidgetData(payload: unknown): WeatherWidgetData {
+  if (!payload || typeof payload !== 'object') {
+    throw new Error(WEATHER_ERROR_MESSAGE);
+  }
+
+  const data = payload as Record<string, unknown>;
+
+  const status = typeof data.status === 'string' ? data.status : null;
+  const waves = typeof data.waves === 'string' ? data.waves : null;
+  const wind = typeof data.wind === 'string' ? data.wind : null;
+
+  if (!status || !waves || !wind) {
+    throw new Error(WEATHER_ERROR_MESSAGE);
+  }
+
+  return { status, waves, wind };
+}
+
 export default function WeatherWidget({ location }: { location: string }) {
-  const data = useWidgetData<Weather>(async () => {
-    const response = await fetch(`/api/weather/widget/${location}`);
-    return response.json();
+  const data = useWidgetData<WeatherWidgetData>(async () => {
+    try {
+      const response = await fetch(
+        buildApiUrl(`/api/weather/widget/${encodeURIComponent(location)}`),
+      );
+
+      if (!response.ok) {
+        throw new Error(WEATHER_ERROR_MESSAGE);
+      }
+
+      const payload = await response.json();
+      return sanitizeWidgetData(payload);
+    } catch (error) {
+      console.error('Erro ao carregar dados do widget meteorológico:', error);
+      return {
+        status: 'Sem dados',
+        waves: '--',
+        wind: '--',
+        message:
+          error instanceof Error && error.message
+            ? error.message
+            : WEATHER_ERROR_MESSAGE,
+      };
+    }
   });
 
   return widget(
     <View>
-      <Text>{data?.status ?? "..."}</Text>
-      <Text>Ondas: {data?.waves ?? "..."}</Text>
-      <Text>Vento: {data?.wind ?? "..."}</Text>
-    </View>
+      <Text>{data?.message ?? data?.status ?? '...'}</Text>
+      <Text>Ondas: {data?.waves ?? '...'}</Text>
+      <Text>Vento: {data?.wind ?? '...'}</Text>
+    </View>,
   );
 }


### PR DESCRIPTION
## Summary
- centralize the mobile API base URL helper that honours `EXPO_PUBLIC_API_URL`
- harden weather fetching with validation and friendly error propagation to dashboards and widgets
- update mobile widgets to reuse the service layer and surface graceful fallbacks when data is unavailable

## Testing
- npm install *(fails: 403 Forbidden for expo-notifications)*
- npm run lint *(fails: expo command unavailable after install failure)*


------
https://chatgpt.com/codex/tasks/task_e_68cc2d43e244832db2cfd4db032f28bf