### PR TITLE
Update weather widget payload to use flattened metrics

### DIFF
--- a/src/routes/weather.py
+++ b/src/routes/weather.py
@@ -196,20 +196,27 @@ def get_weather_widget_data(location):
             return jsonify({'error': 'Local não encontrado'}), 404
         
         # Dados simplificados para widget
+        status = weather_data.get('status')
         widget_data = {
-            'location': weather_data['location'],
-            'status': weather_data['status'],
+            'location': weather_data.get('location'),
+            'status': status,
             'status_text': {
                 'GREEN': 'Condições Excelentes',
-                'YELLOW': 'Atenção Necessária', 
+                'YELLOW': 'Atenção Necessária',
                 'RED': 'Mergulho Cancelado'
-            }.get(weather_data['status'], 'Status Desconhecido'),
-            'wave_height': weather_data['conditions']['wave_height'],
-            'wind_speed': weather_data['conditions']['wind_speed'],
-            'next_update': weather_data['next_update'],
-            'timestamp': weather_data['timestamp']
+            }.get(status, 'Status Desconhecido'),
+            'wave_height': weather_data.get('waveHeight'),
+            'wind_speed': weather_data.get('windSpeed'),
+            'wave_period': weather_data.get('wavePeriod'),
+            'gust': weather_data.get('gust'),
+            'precipitation': weather_data.get('precipitation'),
+            'visibility': weather_data.get('visibility'),
+            'temperature': weather_data.get('temperature'),
+            'water_temperature': weather_data.get('waterTemperature'),
+            'next_update': weather_data.get('next_update'),
+            'timestamp': weather_data.get('timestamp')
         }
-        
+
         return jsonify({
             'success': True,
             'widget': widget_data


### PR DESCRIPTION
## Summary
- read flattened WeatherService metrics when building the widget payload and guard missing data with safe lookups
- expose the widget metrics with the expected naming so the frontend receives serialisable values directly from WeatherService

## Testing
- curl http://127.0.0.1:5000/api/weather/widget/berlengas

------
https://chatgpt.com/codex/tasks/task_e_68cc304aa340832dbaa948de58245771