### PR TITLE
Ajusta fetch meteorológico para local dinâmico

### DIFF
--- a/pwa-corrected/src/App.jsx
+++ b/pwa-corrected/src/App.jsx
@@ -26,7 +26,7 @@ function App() {
   const [currentPage, setCurrentPage] = useState('dashboard')
   const [weatherData, setWeatherData] = useState({
     location: 'Berlengas',
-    status: 'GREEN',
+    status: 'green',
     temperature: 22,
     waterTemperature: 18,
     waveHeight: 1.2,
@@ -56,13 +56,39 @@ function App() {
     }
   }, [])
 
-  const fetchWeatherData = async () => {
+  const fetchWeatherData = async (selectedLocation) => {
+    const location = selectedLocation || weatherData?.location || 'Berlengas'
+    const locationKey = typeof location === 'string' ? location.trim().toLowerCase() : 'berlengas'
+
     try {
-      const response = await fetch('/api/weather/berlengas')
-      if (response.ok) {
-        const data = await response.json()
-        setWeatherData(prev => ({ ...prev, ...data }))
+      const response = await fetch(`/api/weather/current/${encodeURIComponent(locationKey)}`)
+      if (!response.ok) {
+        throw new Error(`Falha ao buscar clima: ${response.status}`)
       }
+
+      const json = await response.json()
+      const apiData = json?.data
+
+      if (!apiData) {
+        throw new Error('Resposta meteorológica inválida')
+      }
+
+      setWeatherData(prev => {
+        const previous = prev || {}
+        const merged = { ...previous, ...apiData }
+
+        if (apiData.status) {
+          merged.status = apiData.status.toLowerCase()
+        } else if (merged.status) {
+          merged.status = merged.status.toLowerCase()
+        }
+
+        if (!merged.location) {
+          merged.location = location
+        }
+
+        return merged
+      })
     } catch (error) {
       console.error('Erro ao buscar dados meteorológicos:', error)
       // Simular dados realistas em caso de erro
@@ -72,7 +98,7 @@ function App() {
         waveHeight: Math.round((0.5 + Math.random() * 2) * 10) / 10,
         windSpeed: Math.round(5 + Math.random() * 25),
         visibility: Math.round(5 + Math.random() * 10),
-        status: Math.random() > 0.8 ? 'YELLOW' : Math.random() > 0.95 ? 'RED' : 'GREEN'
+        status: Math.random() > 0.8 ? 'yellow' : Math.random() > 0.95 ? 'red' : 'green'
       }))
     }
   }

--- a/pwa-corrected/src/components/DashboardModernized.jsx
+++ b/pwa-corrected/src/components/DashboardModernized.jsx
@@ -74,7 +74,8 @@ const DashboardModernized = ({ user, onNavigate }) => {
   }, [])
 
   const getStatusColor = (status) => {
-    switch (status) {
+    const normalizedStatus = status?.toUpperCase()
+    switch (normalizedStatus) {
       case 'GREEN': return 'bg-green-500/20 text-green-300 border-green-500/30'
       case 'YELLOW': return 'bg-yellow-500/20 text-yellow-300 border-yellow-500/30'
       case 'RED': return 'bg-red-500/20 text-red-300 border-red-500/30'
@@ -83,13 +84,16 @@ const DashboardModernized = ({ user, onNavigate }) => {
   }
 
   const getStatusText = (status) => {
-    switch (status) {
+    const normalizedStatus = status?.toUpperCase()
+    switch (normalizedStatus) {
       case 'GREEN': return 'Aulas confirmadas'
       case 'YELLOW': return 'Atenção ao clima'
       case 'RED': return 'Aulas canceladas'
       default: return 'Status desconhecido'
     }
   }
+
+  const weatherStatusUpper = weatherData?.status?.toUpperCase()
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-slate-900 via-blue-900 to-slate-900">
@@ -275,9 +279,9 @@ const DashboardModernized = ({ user, onNavigate }) => {
                   <Badge className={`${getStatusColor(weatherData.status)} border`}>
                     <div className="flex items-center space-x-2">
                       <div className="flex space-x-1">
-                        <div className={`w-2 h-2 rounded-full ${weatherData.status === 'GREEN' ? 'bg-green-400' : weatherData.status === 'YELLOW' ? 'bg-yellow-400' : 'bg-red-400'}`}></div>
-                        <div className={`w-2 h-2 rounded-full ${weatherData.status === 'YELLOW' || weatherData.status === 'RED' ? 'bg-yellow-400' : 'bg-gray-400'}`}></div>
-                        <div className={`w-2 h-2 rounded-full ${weatherData.status === 'RED' ? 'bg-red-400' : 'bg-gray-400'}`}></div>
+                        <div className={`w-2 h-2 rounded-full ${weatherStatusUpper === 'GREEN' ? 'bg-green-400' : weatherStatusUpper === 'YELLOW' ? 'bg-yellow-400' : 'bg-red-400'}`}></div>
+                        <div className={`w-2 h-2 rounded-full ${weatherStatusUpper === 'YELLOW' || weatherStatusUpper === 'RED' ? 'bg-yellow-400' : 'bg-gray-400'}`}></div>
+                        <div className={`w-2 h-2 rounded-full ${weatherStatusUpper === 'RED' ? 'bg-red-400' : 'bg-gray-400'}`}></div>
                       </div>
                       <span>{getStatusText(weatherData.status)}</span>
                     </div>
@@ -413,26 +417,29 @@ const DashboardModernized = ({ user, onNavigate }) => {
                     </tr>
                   </thead>
                   <tbody className="space-y-3">
-                    {upcomingClasses.map((classItem, index) => (
-                      <tr key={index} className="border-b border-slate-700/50">
-                        <td className="py-4 text-white font-medium">{classItem.time}</td>
-                        <td className="py-4 text-slate-300">{classItem.location}</td>
-                        <td className="py-4 text-slate-300">{classItem.instructor}</td>
-                        <td className="py-4 text-slate-300">{classItem.students}</td>
-                        <td className="py-4">
-                          <Badge className={`${getStatusColor(classItem.status)} border`}>
-                            <div className="flex items-center space-x-2">
-                              <div className="flex space-x-1">
-                                <div className={`w-2 h-2 rounded-full ${classItem.status === 'GREEN' ? 'bg-green-400' : classItem.status === 'YELLOW' ? 'bg-yellow-400' : 'bg-red-400'}`}></div>
-                                <div className={`w-2 h-2 rounded-full ${classItem.status === 'YELLOW' || classItem.status === 'RED' ? 'bg-yellow-400' : 'bg-gray-400'}`}></div>
-                                <div className={`w-2 h-2 rounded-full ${classItem.status === 'RED' ? 'bg-red-400' : 'bg-gray-400'}`}></div>
+                    {upcomingClasses.map((classItem, index) => {
+                      const classStatusUpper = classItem.status?.toUpperCase()
+                      return (
+                        <tr key={index} className="border-b border-slate-700/50">
+                          <td className="py-4 text-white font-medium">{classItem.time}</td>
+                          <td className="py-4 text-slate-300">{classItem.location}</td>
+                          <td className="py-4 text-slate-300">{classItem.instructor}</td>
+                          <td className="py-4 text-slate-300">{classItem.students}</td>
+                          <td className="py-4">
+                            <Badge className={`${getStatusColor(classItem.status)} border`}>
+                              <div className="flex items-center space-x-2">
+                                <div className="flex space-x-1">
+                                  <div className={`w-2 h-2 rounded-full ${classStatusUpper === 'GREEN' ? 'bg-green-400' : classStatusUpper === 'YELLOW' ? 'bg-yellow-400' : 'bg-red-400'}`}></div>
+                                  <div className={`w-2 h-2 rounded-full ${classStatusUpper === 'YELLOW' || classStatusUpper === 'RED' ? 'bg-yellow-400' : 'bg-gray-400'}`}></div>
+                                  <div className={`w-2 h-2 rounded-full ${classStatusUpper === 'RED' ? 'bg-red-400' : 'bg-gray-400'}`}></div>
+                                </div>
+                                <span>{classItem.statusText}</span>
                               </div>
-                              <span>{classItem.statusText}</span>
-                            </div>
-                          </Badge>
-                        </td>
-                      </tr>
-                    ))}
+                            </Badge>
+                          </td>
+                        </tr>
+                      )
+                    })}
                   </tbody>
                 </table>
               </div>


### PR DESCRIPTION
## Summary
- atualiza o App para buscar `/api/weather/current/<local>` conforme o local selecionado e fundir o payload da API ao estado existente
- normaliza o status meteorológico para letras minúsculas e mantém fallbacks coerentes em caso de erro
- ajusta o widget administrativo para interpretar o status de forma case-insensitive e manter os indicadores visuais

## Testing
- npm install *(falhou: 403 Forbidden ao baixar dependências do npm registry)*

------
https://chatgpt.com/codex/tasks/task_e_68cc2c273ed8832d85f99ad8e7da24a1