### PR TITLE
Fix weather widget API usage

### DIFF
--- a/pwa-corrected/src/components/WeatherWidget.jsx
+++ b/pwa-corrected/src/components/WeatherWidget.jsx
@@ -14,7 +14,7 @@ import {
 } from 'lucide-react'
 import { fetchCurrentWeather } from '@/services/weatherApi'
 
-const WeatherWidget = ({ location = 'lagos', compact = false }) => {
+const WeatherWidget = ({ location = 'berlengas', compact = false }) => {
   const [data, setData] = useState(null)
   const [isRefreshing, setIsRefreshing] = useState(false)
   const [lastUpdate, setLastUpdate] = useState(null)
@@ -22,7 +22,21 @@ const WeatherWidget = ({ location = 'lagos', compact = false }) => {
   const load = async () => {
     try {
       const result = await fetchCurrentWeather(location)
-      setData(result)
+      const payload = result?.data ?? result
+
+      if (!payload) {
+        throw new Error('Resposta inválida da API meteorológica')
+      }
+
+      const normalizedStatus =
+        typeof payload.status === 'string'
+          ? payload.status.toLowerCase()
+          : 'unknown'
+
+      setData({
+        ...payload,
+        status: normalizedStatus,
+      })
       setLastUpdate(new Date())
     } catch (err) {
       console.error(err)

--- a/pwa-corrected/src/services/weatherApi.js
+++ b/pwa-corrected/src/services/weatherApi.js
@@ -1,5 +1,18 @@
-const RAW_BASE = import.meta.env.VITE_API_BASE_URL || 'https://justdivecrm-1.onrender.com/api'
-const API_BASE = RAW_BASE.replace(/\/+$/, '') // sem barra no fim
+const resolveApiBase = () => {
+  if (typeof window !== 'undefined' && window.location?.origin) {
+    const origin = window.location.origin.replace(/\/+$/, '')
+    return `${origin}/api`
+  }
+
+  const fallback = import.meta.env.VITE_API_BASE_URL
+  if (fallback) {
+    return fallback.replace(/\/+$/, '')
+  }
+
+  return '/api'
+}
+
+const API_BASE = resolveApiBase()
 
 export async function fetchCurrentWeather(local) {
   const url = `${API_BASE}/weather/current/${encodeURIComponent(local)}`


### PR DESCRIPTION
## Summary
- compute the weather API base URL from the current origin when available, falling back to the configured environment variable
- normalize the weather widget request to use a valid backend location, unwrap the API payload and lowercase the status before rendering helpers

## Testing
- pnpm run lint *(fails: existing lint errors in unrelated files such as App.jsx and NotificationManager.jsx)*

------
https://chatgpt.com/codex/tasks/task_e_68cc2c3d3be0832db8e84472cdbd09fc