### PR TITLE
Update weather AI analysis for flat metrics

### DIFF
--- a/src/routes/weather.py
+++ b/src/routes/weather.py
@@ -196,16 +196,26 @@ def get_weather_widget_data(location):
             return jsonify({'error': 'Local não encontrado'}), 404
         
         # Dados simplificados para widget
+        conditions = weather_data.get('conditions', {})
+
+        def get_metric(*keys, default=None):
+            for key in keys:
+                if key in weather_data and weather_data[key] is not None:
+                    return weather_data[key]
+                if key in conditions and conditions[key] is not None:
+                    return conditions[key]
+            return default
+
         widget_data = {
             'location': weather_data['location'],
             'status': weather_data['status'],
             'status_text': {
                 'GREEN': 'Condições Excelentes',
-                'YELLOW': 'Atenção Necessária', 
+                'YELLOW': 'Atenção Necessária',
                 'RED': 'Mergulho Cancelado'
             }.get(weather_data['status'], 'Status Desconhecido'),
-            'wave_height': weather_data['conditions']['wave_height'],
-            'wind_speed': weather_data['conditions']['wind_speed'],
+            'wave_height': get_metric('waveHeight', 'wave_height', default=0),
+            'wind_speed': get_metric('windSpeed', 'wind_speed', default=0),
             'next_update': weather_data['next_update'],
             'timestamp': weather_data['timestamp']
         }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,8 @@
+import os
+import sys
+
+
+PROJECT_ROOT = os.path.dirname(os.path.dirname(__file__))
+
+if PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, PROJECT_ROOT)

--- a/tests/test_openai_service.py
+++ b/tests/test_openai_service.py
@@ -1,0 +1,67 @@
+import pytest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from src.services.openai_service import OpenAIService
+
+
+class DummyResponse(SimpleNamespace):
+    pass
+
+
+@pytest.fixture
+def openai_service_instance():
+    return OpenAIService()
+
+
+def test_analyze_weather_conditions_uses_flat_keys(openai_service_instance):
+    weather_data = {
+        'location': 'Peniche',
+        'status': 'GREEN',
+        'waveHeight': 1.23,
+        'windSpeed': 12.7,
+        'gust': None,
+        'precipitation': 15.4,
+        'visibility': 7.8,
+        'waterTemperature': 17.6,
+    }
+
+    captured_prompt = {}
+
+    def fake_chat_completion_create(model, messages, max_tokens, temperature):
+        captured_prompt['messages'] = messages
+        return DummyResponse(
+            choices=[SimpleNamespace(message=SimpleNamespace(content='Análise gerada'))]
+        )
+
+    with patch('src.services.openai_service.openai.ChatCompletion.create', side_effect=fake_chat_completion_create):
+        result = openai_service_instance.analyze_weather_conditions(weather_data)
+
+    prompt = captured_prompt['messages'][1]['content']
+
+    assert 'Altura das ondas: 1.2m' in prompt
+    assert 'Velocidade do vento: 12.7 kn' in prompt
+    assert 'Rajadas: 0.0 kn' in prompt
+    assert result['conditions_analyzed']['wave_height'] == 1.2
+    assert result['conditions_analyzed']['water_temperature'] == 17.6
+    assert result['analysis'] == 'Análise gerada'
+
+
+def test_extract_weather_metrics_from_nested_conditions(openai_service_instance):
+    weather_data = {
+        'location': 'Sesimbra',
+        'conditions': {
+            'wave_height': 0.9,
+            'wind_speed': 10.2,
+            'gust': 15.1,
+            'precipitation': 5,
+            'visibility': 9,
+            'water_temperature': 18.5,
+        }
+    }
+
+    metrics = openai_service_instance._extract_weather_metrics(weather_data)
+
+    assert metrics['wave_height'] == 0.9
+    assert metrics['wind_speed'] == 10.2
+    assert metrics['water_temperature'] == 18.5

--- a/tests/test_weather_routes.py
+++ b/tests/test_weather_routes.py
@@ -1,0 +1,46 @@
+import pytest
+
+from src.main import app
+from src.routes import weather as weather_module
+
+
+@pytest.fixture
+def client():
+    app.config['TESTING'] = True
+    with app.test_client() as client:
+        yield client
+
+
+def test_weather_analysis_route_returns_textual_response(client, monkeypatch):
+    weather_payload = {
+        'location': 'Peniche',
+        'status': 'GREEN',
+        'waveHeight': 1.1,
+        'windSpeed': 11.5,
+        'gust': 18.2,
+        'precipitation': 20,
+        'visibility': 8,
+        'waterTemperature': 17.2,
+        'timestamp': '2024-01-01T00:00:00Z',
+        'next_update': '2024-01-01T01:00:00Z',
+    }
+
+    analysis_payload = {
+        'analysis': 'Condições analisadas com sucesso.',
+        'timestamp': '2024-01-01T00:00:00Z',
+        'location': 'Peniche',
+        'conditions_analyzed': {
+            'wave_height': 1.1,
+            'wind_speed': 11.5,
+        }
+    }
+
+    monkeypatch.setattr(weather_module.weather_service, 'get_weather_data', lambda location: weather_payload)
+    monkeypatch.setattr(weather_module.openai_service, 'analyze_weather_conditions', lambda data: analysis_payload)
+
+    response = client.get('/api/weather/analysis/peniche')
+
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data['ai_analysis']['analysis'] == analysis_payload['analysis']
+    assert data['ai_analysis']['conditions_analyzed']['wave_height'] == 1.1


### PR DESCRIPTION
## Summary
- normalize weather metric extraction in the OpenAI service to work with flattened Stormglass payloads and keep mock responses aligned
- update the weather widget route to read flattened metrics while remaining compatible with historic payloads
- add pytest coverage for the OpenAI weather analysis, the analysis API route, and configure tests to import project modules

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cc2c3f1760832d97b2b67880baa06f