### PR TITLE
feat: improve push notification registration logging

### DIFF
--- a/mobile-app/hooks/use-push-notifications.ts
+++ b/mobile-app/hooks/use-push-notifications.ts
@@ -1,30 +1,92 @@
 import { useEffect, useState } from 'react';
 import * as Notifications from 'expo-notifications';
 
+import { getApiBase } from '@/utils/config';
+
+const MAX_REGISTRATION_ATTEMPTS = 3;
+const RETRY_BASE_DELAY_MS = 1000;
+
+async function delay(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function registerTokenWithServer(pushToken: string) {
+  const apiBase = getApiBase();
+  const registerUrl = new URL('/api/notifications/register', apiBase).toString();
+
+  console.log('[Notifications] Registrando token com o servidor:', {
+    endpoint: registerUrl,
+    token: pushToken
+  });
+
+  for (let attempt = 1; attempt <= MAX_REGISTRATION_ATTEMPTS; attempt++) {
+    try {
+      console.log(
+        `[Notifications] Tentativa ${attempt}/${MAX_REGISTRATION_ATTEMPTS} de registrar token de push.`
+      );
+
+      const response = await fetch(registerUrl, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ token: pushToken })
+      });
+
+      if (!response.ok) {
+        const responseText = await response.text();
+        throw new Error(`HTTP ${response.status}: ${responseText}`);
+      }
+
+      console.log('[Notifications] Token registrado com sucesso no servidor.');
+      return;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      console.error(
+        `[Notifications] Falha ao registrar token no servidor (tentativa ${attempt}/${MAX_REGISTRATION_ATTEMPTS}): ${message}`
+      );
+
+      if (attempt < MAX_REGISTRATION_ATTEMPTS) {
+        const waitTime = RETRY_BASE_DELAY_MS * attempt;
+        console.log(`[Notifications] Reagendando registro em ${waitTime}ms.`);
+        await delay(waitTime);
+      }
+    }
+  }
+
+  console.warn(
+    '[Notifications] Não foi possível registrar o token após múltiplas tentativas. O servidor pode não enviar notificações.'
+  );
+}
+
 export function usePushNotifications() {
   const [token, setToken] = useState<string | null>(null);
 
   useEffect(() => {
     async function register() {
-      const { status: existingStatus } = await Notifications.getPermissionsAsync();
-      let finalStatus = existingStatus;
-      if (existingStatus !== 'granted') {
-        const { status } = await Notifications.requestPermissionsAsync();
-        finalStatus = status;
-      }
-      if (finalStatus !== 'granted') {
-        return;
-      }
-      const pushToken = (await Notifications.getExpoPushTokenAsync()).data;
-      setToken(pushToken);
+      console.log('[Notifications] Iniciando fluxo de registro de notificações push.');
       try {
-        await fetch('/api/notifications/register', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ token: pushToken })
-        });
-      } catch (e) {
-        console.log('Erro ao registar token de notificação', e);
+        const { status: existingStatus } = await Notifications.getPermissionsAsync();
+        console.log('[Notifications] Status atual das permissões:', existingStatus);
+
+        let finalStatus = existingStatus;
+        if (existingStatus !== 'granted') {
+          const { status } = await Notifications.requestPermissionsAsync();
+          finalStatus = status;
+          console.log('[Notifications] Status após solicitação de permissão:', finalStatus);
+        }
+
+        if (finalStatus !== 'granted') {
+          console.warn('[Notifications] Permissão de notificações não concedida. Registro cancelado.');
+          return;
+        }
+
+        const pushToken = (await Notifications.getExpoPushTokenAsync()).data;
+        console.log('[Notifications] Token Expo obtido com sucesso:', pushToken);
+        setToken(pushToken);
+
+        await registerTokenWithServer(pushToken);
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        console.error('[Notifications] Erro ao configurar notificações push:', message);
       }
     }
 

--- a/mobile-app/utils/config.ts
+++ b/mobile-app/utils/config.ts
@@ -1,0 +1,31 @@
+const DEFAULT_API_BASE = 'http://localhost:5000';
+
+let cachedApiBase: string | null = null;
+
+function normalizeBaseUrl(url: string): string {
+  let normalized = url;
+  while (normalized.endsWith('/')) {
+    normalized = normalized.slice(0, -1);
+  }
+  return normalized;
+}
+
+export function getApiBase(): string {
+  if (cachedApiBase) {
+    return cachedApiBase;
+  }
+
+  const envValue = process.env.EXPO_PUBLIC_API_URL?.trim();
+
+  if (!envValue) {
+    console.warn(
+      '[Config] Variável EXPO_PUBLIC_API_URL não definida. Usando base padrão:',
+      DEFAULT_API_BASE
+    );
+    cachedApiBase = DEFAULT_API_BASE;
+    return cachedApiBase;
+  }
+
+  cachedApiBase = normalizeBaseUrl(envValue);
+  return cachedApiBase;
+}

--- a/src/services/notification_service.py
+++ b/src/services/notification_service.py
@@ -16,8 +16,14 @@ class NotificationService:
 
     def register_token(self, token: str) -> None:
         """Store the Expo push token if it hasn't been registered yet."""
-        if token and token not in self.tokens:
+        if not token:
+            return
+
+        if token not in self.tokens:
             self.tokens.append(token)
+            print(f"Token de notificação registrado: {token}")
+        else:
+            print(f"Token de notificação já registrado: {token}")
 
     def send_notification(self, title: str, message: str) -> None:
         """


### PR DESCRIPTION
## Summary
- adiciona utilitário de configuração para centralizar a leitura da EXPO_PUBLIC_API_URL no app móvel
- atualiza o hook de notificações push para usar a base configurada, registrar logs detalhados e repetir o envio do token em caso de falha
- garante que o servidor registre tokens recebidos via notification_service

## Testing
- PYTHONPATH=. pytest

------
https://chatgpt.com/codex/tasks/task_e_68cc2c4aff80832db8e4b66297a7aa40