### PR TITLE
feat: improve APK distribution workflow

### DIFF
--- a/pwa-corrected/package.json
+++ b/pwa-corrected/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "vite build",
+    "build": "vite build && node ./scripts/sync-static.js",
+    "sync:static": "node ./scripts/sync-static.js",
     "lint": "eslint .",
     "preview": "vite preview"
   },

--- a/pwa-corrected/scripts/sync-static.js
+++ b/pwa-corrected/scripts/sync-static.js
@@ -1,0 +1,66 @@
+import { fileURLToPath } from 'node:url'
+import path from 'node:path'
+import fs from 'node:fs/promises'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+
+const FRONTEND_ROOT = path.resolve(__dirname, '..')
+const DIST_DIR = path.join(FRONTEND_ROOT, 'dist')
+const BACKEND_STATIC_DIR = path.resolve(FRONTEND_ROOT, '..', 'src', 'static')
+const PUBLIC_APK_PATH = path.join(FRONTEND_ROOT, 'public', 'justdive-app.apk')
+const DIST_APK_PATH = path.join(DIST_DIR, 'justdive-app.apk')
+const TARGET_APK_PATH = path.join(BACKEND_STATIC_DIR, 'justdive-app.apk')
+
+async function pathExists(targetPath) {
+  try {
+    await fs.access(targetPath)
+    return true
+  } catch {
+    return false
+  }
+}
+
+async function emptyDirectory(targetDir) {
+  const entries = await fs.readdir(targetDir, { withFileTypes: true })
+  await Promise.all(
+    entries.map((entry) =>
+      fs.rm(path.join(targetDir, entry.name), { recursive: true, force: true })
+    )
+  )
+}
+
+async function copyDirectory(sourceDir, destinationDir) {
+  await fs.cp(sourceDir, destinationDir, { recursive: true })
+}
+
+async function ensureApkFile() {
+  const sourceApk = (await pathExists(DIST_APK_PATH)) ? DIST_APK_PATH : PUBLIC_APK_PATH
+
+  if (!(await pathExists(sourceApk))) {
+    console.warn('[sync-static] APK não encontrado nas pastas dist ou public.')
+    return
+  }
+
+  await fs.copyFile(sourceApk, TARGET_APK_PATH)
+  console.log('[sync-static] APK sincronizado com a pasta estática do backend.')
+}
+
+async function synchronizeStaticAssets() {
+  if (!(await pathExists(DIST_DIR))) {
+    console.error('[sync-static] Diretório dist não encontrado. Execute "npm run build" primeiro.')
+    process.exit(1)
+  }
+
+  await fs.mkdir(BACKEND_STATIC_DIR, { recursive: true })
+  await emptyDirectory(BACKEND_STATIC_DIR)
+  await copyDirectory(DIST_DIR, BACKEND_STATIC_DIR)
+  console.log('[sync-static] Conteúdo do dist copiado para src/static.')
+
+  await ensureApkFile()
+}
+
+synchronizeStaticAssets().catch((error) => {
+  console.error('[sync-static] Falha ao sincronizar assets estáticos:', error)
+  process.exit(1)
+})

--- a/pwa-corrected/src/components/APKDownload.jsx
+++ b/pwa-corrected/src/components/APKDownload.jsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent } from '@/components/ui/card'
 import {
@@ -8,38 +8,101 @@ import {
   AlertCircle,
   Loader2
 } from 'lucide-react'
+import {
+  fetchApkMetadata,
+  resolveApkDownloadName,
+  resolveApkDownloadUrl,
+} from '@/services/apkService'
 
 const APKDownload = ({ className = '' }) => {
   const [downloadState, setDownloadState] = useState('idle') // idle | downloading | success | error
   const [downloadProgress, setDownloadProgress] = useState(0)
+  const [downloadError, setDownloadError] = useState('')
+  const [apkInfo, setApkInfo] = useState(null)
+  const [metadataStatus, setMetadataStatus] = useState('loading') // loading | ready | error
+  const [metadataMessage, setMetadataMessage] = useState('')
+  const [metadataAttempt, setMetadataAttempt] = useState(0)
+
+  useEffect(() => {
+    let active = true
+    const controller = new AbortController()
+
+    const loadMetadata = async () => {
+      setMetadataStatus('loading')
+      setMetadataMessage('')
+
+      try {
+        const metadata = await fetchApkMetadata({ signal: controller.signal })
+
+        if (!active) return
+
+        setApkInfo(metadata)
+        setMetadataStatus('ready')
+      } catch (error) {
+        if (!active || error.name === 'AbortError') return
+
+        const message =
+          error.status === 404
+            ? error.message || 'APK ainda não está disponível para download.'
+            : error.message || 'Não foi possível verificar a disponibilidade do APK.'
+
+        setMetadataStatus('error')
+        setMetadataMessage(message)
+      }
+    }
+
+    loadMetadata()
+
+    return () => {
+      active = false
+      controller.abort()
+    }
+  }, [metadataAttempt])
 
   const handleDownload = async () => {
+    if (metadataStatus !== 'ready') {
+      setDownloadState('error')
+      setDownloadError(
+        metadataMessage || 'O APK ainda não está disponível para download.'
+      )
+
+      setTimeout(() => {
+        setDownloadState('idle')
+        setDownloadError('')
+      }, 4000)
+
+      return
+    }
+
     setDownloadState('downloading')
     setDownloadProgress(0)
+    setDownloadError('')
+
+    const progressInterval = setInterval(() => {
+      setDownloadProgress((prev) => {
+        if (prev >= 95) {
+          return prev
+        }
+
+        return Math.min(95, prev + Math.random() * 15)
+      })
+    }, 200)
 
     try {
-      // Simular progresso de download
-      const progressInterval = setInterval(() => {
-        setDownloadProgress(prev => {
-          if (prev >= 100) {
-            clearInterval(progressInterval)
-            return 100
-          }
-          return Math.min(100, prev + Math.random() * 15)
-        })
-      }, 200)
-
-      // Simular download real do APK (coloque justdive-app.apk em /public)
-      const response = await fetch('/justdive-app.apk')
+      const response = await fetch(resolveApkDownloadUrl(apkInfo))
       if (!response.ok) {
-        throw new Error('Erro ao baixar o APK')
+        const error =
+          response.status === 404
+            ? 'Arquivo APK não encontrado (erro 404).'
+            : 'Erro ao baixar o APK.'
+        throw new Error(error)
       }
 
       const blob = await response.blob()
       const url = window.URL.createObjectURL(blob)
       const link = document.createElement('a')
       link.href = url
-      link.download = 'JUSTDIVE-Academy-v1.0.0.apk'
+      link.download = resolveApkDownloadName(apkInfo)
       document.body.appendChild(link)
       link.click()
       document.body.removeChild(link)
@@ -54,18 +117,28 @@ const APKDownload = ({ className = '' }) => {
         setTimeout(() => {
           setDownloadState('idle')
           setDownloadProgress(0)
+          setDownloadError('')
         }, 3000)
       }, 600)
     } catch (err) {
       console.error(err)
       setDownloadState('error')
+      setDownloadError(err.message || 'Erro ao baixar o APK. Tente novamente.')
 
       // Reset após 3 segundos
       setTimeout(() => {
         setDownloadState('idle')
         setDownloadProgress(0)
+        setDownloadError('')
       }, 3000)
+    } finally {
+      clearInterval(progressInterval)
     }
+  }
+
+  const retryMetadata = () => {
+    setDownloadError('')
+    setMetadataAttempt((attempt) => attempt + 1)
   }
 
   const renderStatus = () => {
@@ -102,7 +175,7 @@ const APKDownload = ({ className = '' }) => {
         <div className="flex flex-col items-center gap-2 text-center">
           <AlertCircle className="w-6 h-6 text-white" />
           <p className="text-blue-100 text-sm">
-            Ocorreu um erro ao baixar o APK. Tente novamente.
+            {downloadError || 'Ocorreu um erro ao baixar o APK. Tente novamente.'}
           </p>
         </div>
       )
@@ -124,16 +197,53 @@ const APKDownload = ({ className = '' }) => {
 
         <Button
           onClick={handleDownload}
-          disabled={downloadState === 'downloading'}
+          disabled={
+            downloadState === 'downloading' || metadataStatus !== 'ready'
+          }
           className="bg-white text-blue-900 hover:bg-blue-100"
         >
           <Download className="w-4 h-4 mr-2" />
-          {downloadState === 'downloading' ? 'Baixando...' : 'Baixar APK'}
+          {downloadState === 'downloading'
+            ? 'Baixando...'
+            : metadataStatus === 'loading'
+              ? 'Verificando...'
+              : metadataStatus === 'error'
+                ? 'Indisponível'
+                : 'Baixar APK'}
         </Button>
 
-        <p className="text-[11px] text-blue-200">
-          Após o download, instale o APK nas configurações do seu Android.
-        </p>
+        {metadataStatus === 'ready' && apkInfo ? (
+          <div className="text-[11px] text-blue-100 text-center space-y-1">
+            <p>Versão: {apkInfo.version}</p>
+            <p>Tamanho: {apkInfo.sizeFormatted}</p>
+          </div>
+        ) : null}
+
+        {metadataStatus === 'loading' ? (
+          <p className="text-[11px] text-blue-200 text-center">
+            Verificando disponibilidade do APK...
+          </p>
+        ) : null}
+
+        {metadataStatus === 'error' ? (
+          <div className="text-[11px] text-red-200 text-center space-y-2">
+            <p>{metadataMessage}</p>
+            <Button
+              size="sm"
+              variant="ghost"
+              onClick={retryMetadata}
+              className="h-7 px-3 text-red-100 hover:bg-red-500/20"
+            >
+              Tentar novamente
+            </Button>
+          </div>
+        ) : null}
+
+        {downloadState !== 'downloading' && metadataStatus === 'ready' ? (
+          <p className="text-[11px] text-blue-200 text-center">
+            Após o download, instale o APK nas configurações do seu Android.
+          </p>
+        ) : null}
       </CardContent>
     </Card>
   )

--- a/pwa-corrected/src/services/apkService.js
+++ b/pwa-corrected/src/services/apkService.js
@@ -1,0 +1,49 @@
+const METADATA_ENDPOINT = '/api/apk/metadata'
+const FALLBACK_DOWNLOAD_URL = '/justdive-app.apk'
+
+export async function fetchApkMetadata(options = {}) {
+  const { signal } = options
+
+  const response = await fetch(METADATA_ENDPOINT, {
+    method: 'GET',
+    headers: {
+      Accept: 'application/json',
+    },
+    signal,
+  })
+
+  if (response.ok) {
+    return response.json()
+  }
+
+  const errorClone = response.clone()
+  let errorMessage = 'Falha ao obter informações do APK.'
+
+  try {
+    const payload = await errorClone.json()
+    if (payload?.message) {
+      errorMessage = payload.message
+    }
+  } catch (jsonError) {
+    try {
+      const text = await errorClone.text()
+      if (text) {
+        errorMessage = text
+      }
+    } catch (textError) {
+      console.error('Erro ao ler resposta de erro do APK:', textError)
+    }
+  }
+
+  const error = new Error(errorMessage)
+  error.status = response.status
+  throw error
+}
+
+export function resolveApkDownloadUrl(metadata) {
+  return metadata?.downloadUrl || FALLBACK_DOWNLOAD_URL
+}
+
+export function resolveApkDownloadName(metadata) {
+  return metadata?.downloadFileName || metadata?.fileName || 'justdive-app.apk'
+}


### PR DESCRIPTION
## Summary
- expose APK metadata and download routes in Flask so the frontend can validate availability and serve the binary
- add a post-build sync script that copies the Vite dist output plus the APK into the backend static folder
- load APK metadata in the PWA download components to show version/size details and provide clearer error handling when a 404 occurs

## Testing
- PYTHONPATH=. pytest
- npm install *(fails: npm registry returned 403 for date-fns)*

------
https://chatgpt.com/codex/tasks/task_e_68cc2c50aa70832da37f0d1bf6feacd6