### PR TITLE
Atualiza consumo da API de meteorologia

### DIFF
--- a/pwa-corrected/src/App.jsx
+++ b/pwa-corrected/src/App.jsx
@@ -58,10 +58,18 @@ function App() {
 
   const fetchWeatherData = async () => {
     try {
-      const response = await fetch('/api/weather/berlengas')
+      const locationSlug = encodeURIComponent((weatherData?.location || 'Berlengas').toLowerCase())
+      const response = await fetch(`/api/weather/current/${locationSlug}`)
       if (response.ok) {
-        const data = await response.json()
-        setWeatherData(prev => ({ ...prev, ...data }))
+        const payload = await response.json()
+        if (payload?.success && payload?.data) {
+          setWeatherData(prev => ({ ...prev, ...payload.data }))
+        } else {
+          console.error('Resposta inválida da API de meteorologia:', payload)
+          throw new Error('Resposta inválida da API de meteorologia')
+        }
+      } else {
+        throw new Error(`Falha na solicitação de meteorologia: ${response.status}`)
       }
     } catch (error) {
       console.error('Erro ao buscar dados meteorológicos:', error)


### PR DESCRIPTION
## Summary
- atualizar o fetch de meteorologia para usar o endpoint `/api/weather/current` com o local padrão do app
- validar o envelope retornado antes de aplicar `payload.data` ao estado mantendo o fallback em caso de erro

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cc3aca2570832d8ddace40c39ee6b1