### PR TITLE
Improve weather widget defaults and API payload handling

### DIFF
--- a/pwa-corrected/src/services/weatherApi.js
+++ b/pwa-corrected/src/services/weatherApi.js
@@ -2,8 +2,28 @@ const RAW_BASE = import.meta.env.VITE_API_BASE_URL || 'https://justdivecrm-1.onr
 const API_BASE = RAW_BASE.replace(/\/+$/, '') // sem barra no fim
 
 export async function fetchCurrentWeather(local) {
-  const url = `${API_BASE}/weather/current/${encodeURIComponent(local)}`
+  const envLocation =
+    typeof import.meta.env.VITE_DEFAULT_LOCATION === 'string'
+      ? import.meta.env.VITE_DEFAULT_LOCATION.trim()
+      : ''
+  const resolvedLocation =
+    typeof local === 'string' && local.trim() ? local.trim() : envLocation || 'berlengas'
+
+  const url = `${API_BASE}/weather/current/${encodeURIComponent(resolvedLocation)}`
   const res = await fetch(url, { headers: { Accept: 'application/json' } })
-  if (!res.ok) throw new Error(`HTTP ${res.status} ${res.statusText}`)
-  return res.json()
+
+  if (!res.ok) {
+    throw new Error(`HTTP ${res.status} ${res.statusText}`)
+  }
+
+  const payload = await res.json()
+
+  if (payload?.success === false) {
+    const message = payload?.message || 'Erro ao obter condições meteorológicas'
+    const error = new Error(message)
+    error.response = payload
+    throw error
+  }
+
+  return payload?.payload?.data ?? payload?.data ?? payload
 }


### PR DESCRIPTION
## Summary
- ensure the weather widget falls back to a supported location from the environment (or Berlengas) when none is provided
- normalize fetched weather payloads before storing them in the widget state so status checks remain consistent
- sanitize the weather API client to reuse the default location, surface API errors, and return the payload data directly

## Testing
- npm run lint *(fails: existing lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68cc3acfb604832d988e45928f8c2a3a