### PR TITLE
Add timedelta import for weather history filtering

### DIFF
--- a/src/services/supabase_service.py
+++ b/src/services/supabase_service.py
@@ -5,7 +5,7 @@ import os
 import requests
 from typing import Dict, List, Optional, Any
 import json
-from datetime import datetime
+from datetime import datetime, timedelta
 from src.utils.encryption import encrypt_sensitive_data, decrypt_sensitive_data
 
 class SupabaseService:


### PR DESCRIPTION
## Summary
- include timedelta in Supabase service datetime import so weather history range calculation works

## Testing
- python - <<'PY'
import os
os.environ['SUPABASE_URL'] = 'https://example.supabase.co'
os.environ['SUPABASE_SERVICE_ROLE_KEY'] = 'service-key'

from unittest.mock import patch, Mock
from src.main import app

with app.test_client() as client:
    with patch('src.services.supabase_service.requests.get') as mock_get:
        mock_response = Mock()
        mock_response.status_code = 200
        mock_response.json.return_value = [{'timestamp': '2024-01-01T00:00:00Z'}]
        mock_get.return_value = mock_response

        response = client.get('/api/weather/history/test-location?hours=12')
        print('status:', response.status_code)
        print('json:', response.json)
        print('called url:', mock_get.call_args[0][0])
        print('called headers:', mock_get.call_args[1]['headers'].keys())
PY

------
https://chatgpt.com/codex/tasks/task_e_68cc3ae10128832dbbb21ad1389f77b0