### PR TITLE
Ajusta payload do chat e compatibiliza backend

### DIFF
--- a/pwa-corrected/src/services/AIService.js
+++ b/pwa-corrected/src/services/AIService.js
@@ -33,9 +33,10 @@ class AIService {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
+          message,
           messages: [
             { role: 'system', content: 'Você é o assistente virtual da JUSTDIVE Academy.' },
-          { role: 'user', content: message }
+            { role: 'user', content: message }
           ]
         })
       });

--- a/src/routes/ai.py
+++ b/src/routes/ai.py
@@ -8,11 +8,21 @@ ai_bp = Blueprint('ai', __name__, url_prefix='/api/ai')
 def chat():
     """Endpoint de chat simples com o serviço OpenAI"""
     try:
-        data = request.get_json()
-        if not data or 'message' not in data:
+        data = request.get_json() or {}
+        message = data.get('message')
+
+        if message is None:
+            messages = data.get('messages')
+            if isinstance(messages, list) and messages:
+                # Tenta obter o conteúdo da última mensagem do histórico
+                for item in reversed(messages):
+                    if isinstance(item, dict) and item.get('content'):
+                        message = item['content']
+                        break
+
+        if not message:
             return jsonify({'error': 'Mensagem é obrigatória'}), 400
 
-        message = data['message']
         response_text = openai_service.chat(message)
         return jsonify({'success': True, 'response': response_text})
     except Exception as e:


### PR DESCRIPTION
## Summary
- inclui o campo message no payload enviado pelo serviço de chat da PWA para garantir compatibilidade com o backend
- adapta o endpoint /api/ai/chat para aceitar requisições com message isolado ou apenas com o array messages, extraindo o conteúdo adequado

## Testing
- PYTHONPATH=. pytest

------
https://chatgpt.com/codex/tasks/task_e_68cc3ae6ea90832d862769ebff1a09a3